### PR TITLE
Only allocate text transformer once.

### DIFF
--- a/goaway.go
+++ b/goaway.go
@@ -11,7 +11,10 @@ import (
 
 const Space = " "
 
-var defaultProfanityDetector *ProfanityDetector
+var (
+	defaultProfanityDetector *ProfanityDetector
+	removeAccentsTransformer transform.Transformer
+)
 
 // ProfanityDetector
 type ProfanityDetector struct {
@@ -103,8 +106,10 @@ func (g ProfanityDetector) sanitize(s string) string {
 }
 
 func removeAccents(s string) string {
-	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
-	output, _, _ := transform.String(t, s)
+	if removeAccentsTransformer == nil {
+		removeAccentsTransformer = transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	}
+	output, _, _ := transform.String(removeAccentsTransformer, s)
 	return output
 }
 


### PR DESCRIPTION
Old bench:
```console
goos: linux
goarch: amd64
pkg: github.com/TwinProduction/go-away
BenchmarkIsProfaneWhenShortStringHasNoProfanity-8                                                 	  410056	      2879 ns/op	    8752 B/op	       6 allocs/op
BenchmarkIsProfaneWhenShortStringHasProfanityAtTheStart-8                                         	  455678	      2491 ns/op	    8752 B/op	       6 allocs/op
BenchmarkIsProfaneWhenShortStringHasProfanityInTheMiddle-8                                        	  445470	      2639 ns/op	    8752 B/op	       6 allocs/op
BenchmarkIsProfaneWhenShortStringHasProfanityAtTheEnd-8                                           	  428016	      2750 ns/op	    8752 B/op	       6 allocs/op
BenchmarkIsProfaneWhenMediumStringHasNoProfanity-8                                                	  380592	      3151 ns/op	    8912 B/op	      11 allocs/op
BenchmarkIsProfaneWhenMediumStringHasProfanityAtTheStart-8                                        	  373015	      2969 ns/op	    8912 B/op	      11 allocs/op
BenchmarkIsProfaneWhenMediumStringHasProfanityInTheMiddle-8                                       	  433670	      2838 ns/op	    8912 B/op	      11 allocs/op
BenchmarkIsProfaneWhenMediumStringHasProfanityAtTheEnd-8                                          	  419103	      2866 ns/op	    8912 B/op	      11 allocs/op
BenchmarkIsProfaneWhenLongStringHasNoProfanity-8                                                  	  142447	      8092 ns/op	    9808 B/op	      13 allocs/op
BenchmarkIsProfaneWhenLongStringHasProfanityAtTheStart-8                                          	  170215	      7055 ns/op	    9808 B/op	      13 allocs/op
BenchmarkIsProfaneWhenLongStringHasProfanityInTheMiddle-8                                         	  154742	      7824 ns/op	    9808 B/op	      13 allocs/op
BenchmarkIsProfaneWhenLongStringHasProfanityAtTheEnd-8                                            	  181903	      6374 ns/op	    9808 B/op	      13 allocs/op
BenchmarkProfanityDetector_WithSanitizeAccentsSetToFalseWhenLongStringHasProfanityAtTheStart-8    	  273676	      4232 ns/op	     656 B/op	       5 allocs/op
BenchmarkProfanityDetector_WithSanitizeAccentsSetToFalseWhenLongStringHasProfanityInTheMiddle-8   	  251042	      4856 ns/op	     656 B/op	       5 allocs/op
BenchmarkProfanityDetector_WithSanitizeAccentsSetToFalseWhenLongStringHasProfanityAtTheEnd-8      	  348662	      3332 ns/op	     656 B/op	       5 allocs/op
PASS
ok  	github.com/TwinProduction/go-away	19.160s
```
New bench:
```console
goos: linux
goarch: amd64
pkg: github.com/TwinProduction/go-away
BenchmarkIsProfaneWhenShortStringHasNoProfanity-8                                                 	  606076	      1834 ns/op	     256 B/op	       1 allocs/op
BenchmarkIsProfaneWhenShortStringHasProfanityAtTheStart-8                                         	  790260	      1445 ns/op	     256 B/op	       1 allocs/op
BenchmarkIsProfaneWhenShortStringHasProfanityInTheMiddle-8                                        	  826394	      1442 ns/op	     256 B/op	       1 allocs/op
BenchmarkIsProfaneWhenShortStringHasProfanityAtTheEnd-8                                           	  798075	      1448 ns/op	     256 B/op	       1 allocs/op
BenchmarkIsProfaneWhenMediumStringHasNoProfanity-8                                                	  634326	      1915 ns/op	     416 B/op	       6 allocs/op
BenchmarkIsProfaneWhenMediumStringHasProfanityAtTheStart-8                                        	  640370	      1822 ns/op	     416 B/op	       6 allocs/op
BenchmarkIsProfaneWhenMediumStringHasProfanityInTheMiddle-8                                       	  672810	      1673 ns/op	     416 B/op	       6 allocs/op
BenchmarkIsProfaneWhenMediumStringHasProfanityAtTheEnd-8                                          	  727614	      1651 ns/op	     416 B/op	       6 allocs/op
BenchmarkIsProfaneWhenLongStringHasNoProfanity-8                                                  	  169524	      6887 ns/op	    1312 B/op	       8 allocs/op
BenchmarkIsProfaneWhenLongStringHasProfanityAtTheStart-8                                          	  195616	      5931 ns/op	    1312 B/op	       8 allocs/op
BenchmarkIsProfaneWhenLongStringHasProfanityInTheMiddle-8                                         	  182773	      6453 ns/op	    1312 B/op	       8 allocs/op
BenchmarkIsProfaneWhenLongStringHasProfanityAtTheEnd-8                                            	  236205	      5004 ns/op	    1312 B/op	       8 allocs/op
BenchmarkProfanityDetector_WithSanitizeAccentsSetToFalseWhenLongStringHasProfanityAtTheStart-8    	  283921	      4163 ns/op	     656 B/op	       5 allocs/op
BenchmarkProfanityDetector_WithSanitizeAccentsSetToFalseWhenLongStringHasProfanityInTheMiddle-8   	  253231	      4834 ns/op	     656 B/op	       5 allocs/op
BenchmarkProfanityDetector_WithSanitizeAccentsSetToFalseWhenLongStringHasProfanityAtTheEnd-8      	  354802	      3344 ns/op	     656 B/op	       5 allocs/op
PASS
ok  	github.com/TwinProduction/go-away	19.057s
```
