### PR TITLE
Allow different dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ profanityDetector := goaway.NewProfanityDetector().WithSanitizeLeetSpeak(false).
 profanityDetector.IsProfane("b!tch") // returns false because we're not sanitizing special characters
 ```
 
+By default, the `NewProfanityDetector` constructor uses the default dictionary for load the configuration, that you could see on the next files:
+* profanities.go
+* falsenegatives.go
+* falsepositives.go
+
+If you need to load a different dictionary, you could create a new instance of `ProfanityDetector` on this way:
+
+```
+profanities    := []string{"word1", "word2"}
+falseNegatives := []string{"word"}
+falsePositives := []string{"word1bad", "word2bad"}
+
+profanityDetector := goaway.NewProfanityDetector().WithCustomDictionary(profanities, falseNegatives, falsePositives)
+```
 
 ## In the background
 

--- a/falsenegatives.go
+++ b/falsenegatives.go
@@ -1,14 +1,14 @@
 package goaway
 
-// defaultFalseNegatives is a list of defaultProfanities that are checked for before the defaultFalsePositives are removed
+// DefaultFalseNegatives is a list of DefaultProfanities that are checked for before the DefaultFalsePositives are removed
 //
 // This is reserved for words that may be incorrectly filtered as false positives.
 //
 // Alternatively, words that are long, or that should mark a string as profane no what the context is
 // or whether the word is part of another word can also be included.
 //
-// Note that there is a test that prevents words from being in both defaultProfanities and defaultFalseNegatives,
-var defaultFalseNegatives = []string{
+// Note that there is a test that prevents words from being in both DefaultProfanities and DefaultFalseNegatives,
+var DefaultFalseNegatives = []string{
 	"asshole",
 	"dumbass", // ass -> bASS (FP) -> dumBASS
 	"nigger",

--- a/falsenegatives.go
+++ b/falsenegatives.go
@@ -1,14 +1,14 @@
 package goaway
 
-// falseNegatives is a list of profanities that are checked for before the falsePositives are removed
+// defaultFalseNegatives is a list of defaultProfanities that are checked for before the defaultFalsePositives are removed
 //
 // This is reserved for words that may be incorrectly filtered as false positives.
 //
 // Alternatively, words that are long, or that should mark a string as profane no what the context is
 // or whether the word is part of another word can also be included.
 //
-// Note that there is a test that prevents words from being in both profanities and falseNegatives,
-var falseNegatives = []string{
+// Note that there is a test that prevents words from being in both defaultProfanities and defaultFalseNegatives,
+var defaultFalseNegatives = []string{
 	"asshole",
 	"dumbass", // ass -> bASS (FP) -> dumBASS
 	"nigger",

--- a/falsenegatives.go
+++ b/falsenegatives.go
@@ -1,6 +1,6 @@
 package goaway
 
-// DefaultFalseNegatives is a list of DefaultProfanities that are checked for before the DefaultFalsePositives are removed
+// DefaultFalseNegatives is a list of profanities that are checked for before the DefaultFalsePositives are removed
 //
 // This is reserved for words that may be incorrectly filtered as false positives.
 //

--- a/falsepositives.go
+++ b/falsepositives.go
@@ -1,7 +1,7 @@
 package goaway
 
-// defaultFalsePositives is a list of words that may wrongly trigger the defaultProfanities
-var defaultFalsePositives = []string{
+// DefaultFalsePositives is a list of words that may wrongly trigger the DefaultProfanities
+var DefaultFalsePositives = []string{
 	"arsenal",
 	"assassin",
 	"assaying", // was saying

--- a/falsepositives.go
+++ b/falsepositives.go
@@ -1,7 +1,7 @@
 package goaway
 
-// falsePositives is a list of words that may wrongly trigger the profanities
-var falsePositives = []string{
+// defaultFalsePositives is a list of words that may wrongly trigger the defaultProfanities
+var defaultFalsePositives = []string{
 	"arsenal",
 	"assassin",
 	"assaying", // was saying

--- a/goaway.go
+++ b/goaway.go
@@ -150,7 +150,7 @@ func removeAccents(s string) string {
 	return s
 }
 
-// IsProfane checks whether there are any defaultProfanities in a given string (word or sentence).
+// IsProfane checks whether there are any profanities in a given string (word or sentence).
 // Uses the default ProfanityDetector
 func IsProfane(s string) bool {
 	if defaultProfanityDetector == nil {

--- a/goaway.go
+++ b/goaway.go
@@ -77,7 +77,7 @@ func (g *ProfanityDetector) WithCustomDictionary(profanities, falseNegatives, fa
 	return g
 }
 
-// IsProfane takes in a string (word or sentence) and look for DefaultProfanities.
+// IsProfane takes in a string (word or sentence) and look for profanities.
 // Returns a boolean
 func (g *ProfanityDetector) IsProfane(s string) bool {
 	s = g.sanitize(s)
@@ -91,7 +91,7 @@ func (g *ProfanityDetector) IsProfane(s string) bool {
 	for _, word := range g.falsePositives {
 		s = strings.Replace(s, word, "", -1)
 	}
-	// Check for DefaultProfanities
+	// Check for profanities
 	for _, word := range g.profanities {
 		if match := strings.Contains(s, word); match {
 			return true

--- a/goaway.go
+++ b/goaway.go
@@ -25,14 +25,23 @@ type ProfanityDetector struct {
 	sanitizeSpecialCharacters bool
 	sanitizeLeetSpeak         bool
 	sanitizeAccents           bool
+
+	profanities    []string
+	falseNegatives []string
+	falsePositives []string
 }
 
 // NewProfanityDetector creates a new ProfanityDetector
 func NewProfanityDetector() *ProfanityDetector {
+
 	return &ProfanityDetector{
 		sanitizeSpecialCharacters: true,
 		sanitizeLeetSpeak:         true,
 		sanitizeAccents:           true,
+
+		profanities:    defaultProfanities,
+		falseNegatives: defaultFalseNegatives,
+		falsePositives: defaultFalsePositives,
 	}
 }
 
@@ -58,22 +67,32 @@ func (g *ProfanityDetector) WithSanitizeAccents(sanitize bool) *ProfanityDetecto
 	return g
 }
 
-// IsProfane takes in a string (word or sentence) and look for profanities.
+// WithCustomDictionary allows configuring whether the sanitization process should also take into account
+// custom profanities, false negatives and false positives dictionaries
+func (g *ProfanityDetector) WithCustomDictionary(profanities, falseNegatives, falsePositives []string) *ProfanityDetector {
+	g.profanities = profanities
+	g.falseNegatives = falseNegatives
+	g.falsePositives = falsePositives
+
+	return g
+}
+
+// IsProfane takes in a string (word or sentence) and look for defaultProfanities.
 // Returns a boolean
 func (g *ProfanityDetector) IsProfane(s string) bool {
 	s = g.sanitize(s)
 	// Check for false false positives
-	for _, word := range falseNegatives {
+	for _, word := range g.falseNegatives {
 		if match := strings.Contains(s, word); match {
 			return true
 		}
 	}
 	// Remove false positives
-	for _, word := range falsePositives {
+	for _, word := range g.falsePositives {
 		s = strings.Replace(s, word, "", -1)
 	}
-	// Check for profanities
-	for _, word := range profanities {
+	// Check for defaultProfanities
+	for _, word := range g.profanities {
 		if match := strings.Contains(s, word); match {
 			return true
 		}
@@ -131,7 +150,7 @@ func removeAccents(s string) string {
 	return s
 }
 
-// IsProfane checks whether there are any profanities in a given string (word or sentence).
+// IsProfane checks whether there are any defaultProfanities in a given string (word or sentence).
 // Uses the default ProfanityDetector
 func IsProfane(s string) bool {
 	if defaultProfanityDetector == nil {

--- a/goaway.go
+++ b/goaway.go
@@ -39,9 +39,9 @@ func NewProfanityDetector() *ProfanityDetector {
 		sanitizeLeetSpeak:         true,
 		sanitizeAccents:           true,
 
-		profanities:    defaultProfanities,
-		falseNegatives: defaultFalseNegatives,
-		falsePositives: defaultFalsePositives,
+		profanities:    DefaultProfanities,
+		falseNegatives: DefaultFalseNegatives,
+		falsePositives: DefaultFalsePositives,
 	}
 }
 
@@ -77,7 +77,7 @@ func (g *ProfanityDetector) WithCustomDictionary(profanities, falseNegatives, fa
 	return g
 }
 
-// IsProfane takes in a string (word or sentence) and look for defaultProfanities.
+// IsProfane takes in a string (word or sentence) and look for DefaultProfanities.
 // Returns a boolean
 func (g *ProfanityDetector) IsProfane(s string) bool {
 	s = g.sanitize(s)
@@ -91,7 +91,7 @@ func (g *ProfanityDetector) IsProfane(s string) bool {
 	for _, word := range g.falsePositives {
 		s = strings.Replace(s, word, "", -1)
 	}
-	// Check for defaultProfanities
+	// Check for DefaultProfanities
 	for _, word := range g.profanities {
 		if match := strings.Contains(s, word); match {
 			return true

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestNoDuplicatesBetweenProfanitiesAndFalseNegatives(t *testing.T) {
-	for _, profanity := range defaultProfanities {
-		for _, falseNegative := range defaultFalseNegatives {
+	for _, profanity := range DefaultProfanities {
+		for _, falseNegative := range DefaultFalseNegatives {
 			if profanity == falseNegative {
 				t.Errorf("'%s' is already in 'falseNegatives', there's no need to have it in 'profanities' too", profanity)
 			}
@@ -28,7 +28,7 @@ func TestBadWords(t *testing.T) {
 		},
 		{
 			name:   "With Custom Dictionary",
-			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, DefaultFalseNegatives, DefaultFalsePositives),
 		},
 	}
 
@@ -57,7 +57,7 @@ func TestBadWordsWithAccentedLetters(t *testing.T) {
 		},
 		{
 			name:   "With Custom Dictionary",
-			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, DefaultFalseNegatives, DefaultFalsePositives),
 		},
 	}
 	for _, tt := range tests {
@@ -88,7 +88,7 @@ func TestSentencesWithBadWords(t *testing.T) {
 		},
 		{
 			name:   "With Custom Dictionary",
-			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, DefaultFalseNegatives, DefaultFalsePositives),
 		},
 	}
 
@@ -117,7 +117,7 @@ func TestSneakyBadWords(t *testing.T) {
 		},
 		{
 			name:   "With Custom Dictionary",
-			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, DefaultFalseNegatives, DefaultFalsePositives),
 		},
 	}
 	for _, tt := range tests {
@@ -148,7 +148,7 @@ func TestSentencesWithSneakyBadWords(t *testing.T) {
 		},
 		{
 			name:   "With Custom Dictionary",
-			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, DefaultFalseNegatives, DefaultFalsePositives),
 		},
 	}
 
@@ -176,7 +176,7 @@ func TestNormalWords(t *testing.T) {
 		},
 		{
 			name:   "With Custom Dictionary",
-			goAway: NewProfanityDetector().WithCustomDictionary(defaultProfanities, defaultFalseNegatives, defaultFalsePositives),
+			goAway: NewProfanityDetector().WithCustomDictionary(DefaultProfanities, DefaultFalseNegatives, DefaultFalsePositives),
 		},
 	}
 
@@ -245,7 +245,7 @@ func TestFalsePositives(t *testing.T) {
 		},
 		{
 			name:   "With Custom Dictionary",
-			goAway: NewProfanityDetector().WithCustomDictionary(defaultProfanities, defaultFalseNegatives, defaultFalsePositives),
+			goAway: NewProfanityDetector().WithCustomDictionary(DefaultProfanities, DefaultFalseNegatives, DefaultFalsePositives),
 		},
 	}
 
@@ -275,7 +275,7 @@ func TestFalseNegatives(t *testing.T) {
 		},
 		{
 			name:   "With Custom Dictionary",
-			goAway: NewProfanityDetector().WithCustomDictionary(defaultProfanities, defaultFalseNegatives, defaultFalsePositives),
+			goAway: NewProfanityDetector().WithCustomDictionary(DefaultProfanities, DefaultFalseNegatives, DefaultFalsePositives),
 		},
 	}
 
@@ -303,7 +303,7 @@ func TestSentencesWithFalsePositivesAndProfanities(t *testing.T) {
 		},
 		{
 			name:   "With Custom Dictionary",
-			goAway: NewProfanityDetector().WithCustomDictionary(defaultProfanities, defaultFalseNegatives, defaultFalsePositives),
+			goAway: NewProfanityDetector().WithCustomDictionary(DefaultProfanities, DefaultFalseNegatives, DefaultFalsePositives),
 		},
 	}
 

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -5,77 +5,189 @@ import (
 )
 
 func TestNoDuplicatesBetweenProfanitiesAndFalseNegatives(t *testing.T) {
-	for _, profanity := range profanities {
-		for _, falseNegative := range falseNegatives {
+	for _, profanity := range defaultProfanities {
+		for _, falseNegative := range defaultFalseNegatives {
 			if profanity == falseNegative {
-				t.Errorf("'%s' is already in 'falseNegatives', there's no need to have it in 'profanities' too", profanity)
+				t.Errorf("'%s' is already in 'defaultFalseNegatives', there's no need to have it in 'defaultProfanities' too", profanity)
 			}
 		}
 	}
 }
 
 func TestBadWords(t *testing.T) {
+	profanities := []string{"fuck", "ass", "poop", "penis", "bitch"}
 	words := []string{"fuck", "ass", "poop", "penis", "bitch"}
-	goAway := NewProfanityDetector()
-	for _, w := range words {
-		if !goAway.IsProfane(w) {
-			t.Error("Expected true, got false from word", w)
-		}
+
+	tests := []struct {
+		name   string
+		goAway *ProfanityDetector
+	}{
+		{
+			name:   "With Default Dictionary",
+			goAway: NewProfanityDetector(),
+		},
+		{
+			name:   "With Custom Dictionary",
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, w := range words {
+				if !tt.goAway.IsProfane(w) {
+					t.Error("Expected true, got false from word", w)
+				}
+			}
+		})
 	}
 }
 
 func TestBadWordsWithAccentedLetters(t *testing.T) {
+	profanities := []string{"fuck", "ass", "poop", "penis", "bitch"}
 	words := []string{"fučk", "ÄšŚ", "pÓöp", "pÉnìŚ", "bitčh"}
-	for _, w := range words {
-		if !NewProfanityDetector().WithSanitizeAccents(true).IsProfane(w) {
-			t.Error("Expected true because sanitizeAccents is set to true, got false from word", w)
-		}
-		if NewProfanityDetector().WithSanitizeAccents(false).IsProfane(w) {
-			t.Error("Expected false because sanitizeAccents is set to false, got true from word", w)
-		}
+
+	tests := []struct {
+		name   string
+		goAway *ProfanityDetector
+	}{
+		{
+			name:   "With Default Dictionary",
+			goAway: NewProfanityDetector(),
+		},
+		{
+			name:   "With Custom Dictionary",
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, w := range words {
+				if !tt.goAway.WithSanitizeAccents(true).IsProfane(w) {
+					t.Error("Expected true because sanitizeAccents is set to true, got false from word", w)
+				}
+				if tt.goAway.WithSanitizeAccents(false).IsProfane(w) {
+					t.Error("Expected false because sanitizeAccents is set to false, got true from word", w)
+				}
+			}
+		})
 	}
 }
 
 func TestSentencesWithBadWords(t *testing.T) {
+	profanities := []string{"fuck", "ass", "poop", "penis", "bitch"}
 	sentences := []string{"What the fuck is your problem", "Go away, asshole!"}
-	goAway := NewProfanityDetector()
-	for _, s := range sentences {
-		if !goAway.IsProfane(s) {
-			t.Error("Expected true, got false from sentence", s)
-		}
+
+	tests := []struct {
+		name   string
+		goAway *ProfanityDetector
+	}{
+		{
+			name:   "With Default Dictionary",
+			goAway: NewProfanityDetector(),
+		},
+		{
+			name:   "With Custom Dictionary",
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, s := range sentences {
+				if !tt.goAway.IsProfane(s) {
+					t.Error("Expected true, got false from sentence", s)
+				}
+			}
+		})
 	}
 }
 
 func TestSneakyBadWords(t *testing.T) {
+	profanities := []string{"fuck", "ass", "poop", "penis", "bitch", "arse", "shit", "btch"}
 	words := []string{"A$$", "4ss", "4s$", "a S s", "a $ s", "@$$h073", "f    u     c k", "4r5e", "5h1t", "5hit", "a55", "ar5e", "a_s_s", "b!tch", "b!+ch"}
-	goAway := NewProfanityDetector()
-	for _, w := range words {
-		if !goAway.IsProfane(w) {
-			t.Error("Expected true, got false from word", w)
-		}
+
+	tests := []struct {
+		name   string
+		goAway *ProfanityDetector
+	}{
+		{
+			name:   "With Default Dictionary",
+			goAway: NewProfanityDetector(),
+		},
+		{
+			name:   "With Custom Dictionary",
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, w := range words {
+				if !tt.goAway.IsProfane(w) {
+					t.Error("Expected true, got false from word", w)
+				}
+			}
+		})
 	}
 }
 
 func TestSentencesWithSneakyBadWords(t *testing.T) {
+	profanities := []string{"poop", "asshole"}
 	sentences := []string{
 		"You smell p00p",
 		"Go away, a$$h0l3!",
 	}
-	goAway := NewProfanityDetector()
-	for _, s := range sentences {
-		if !goAway.IsProfane(s) {
-			t.Error("Expected true, got false from sentence", s)
-		}
+
+	tests := []struct {
+		name   string
+		goAway *ProfanityDetector
+	}{
+		{
+			name:   "With Default Dictionary",
+			goAway: NewProfanityDetector(),
+		},
+		{
+			name:   "With Custom Dictionary",
+			goAway: NewProfanityDetector().WithCustomDictionary(profanities, defaultFalseNegatives, defaultFalsePositives),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, s := range sentences {
+				if !tt.goAway.IsProfane(s) {
+					t.Error("Expected true, got false from sentence", s)
+				}
+			}
+		})
 	}
 }
 
 func TestNormalWords(t *testing.T) {
 	words := []string{"hello", "world", "whats", "up"}
-	goAway := NewProfanityDetector()
-	for _, w := range words {
-		if goAway.IsProfane(w) {
-			t.Error("Expected false, got true from word", w)
-		}
+
+	tests := []struct {
+		name   string
+		goAway *ProfanityDetector
+	}{
+		{
+			name:   "With Default Dictionary",
+			goAway: NewProfanityDetector(),
+		},
+		{
+			name:   "With Custom Dictionary",
+			goAway: NewProfanityDetector().WithCustomDictionary(defaultProfanities, defaultFalseNegatives, defaultFalsePositives),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, w := range words {
+				if tt.goAway.IsProfane(w) {
+					t.Error("Expected false, got true from word", w)
+				}
+			}
+		})
 	}
 }
 
@@ -99,6 +211,7 @@ func TestSentencesWithNoProfanities(t *testing.T) {
 		"Yes, really",
 		"Call me at 9, ok?",
 	}
+
 	for _, s := range sentences {
 		if IsProfane(s) {
 			t.Error("Expected false, got false from sentence", s)
@@ -121,11 +234,29 @@ func TestFalsePositives(t *testing.T) {
 		"cassandra",
 		"just push it down the ledge", // puSH IT
 	}
-	goAway := NewProfanityDetector()
-	for _, s := range sentences {
-		if goAway.IsProfane(s) {
-			t.Error("Expected false, got true from:", s)
-		}
+
+	tests := []struct {
+		name   string
+		goAway *ProfanityDetector
+	}{
+		{
+			name:   "With Default Dictionary",
+			goAway: NewProfanityDetector(),
+		},
+		{
+			name:   "With Custom Dictionary",
+			goAway: NewProfanityDetector().WithCustomDictionary(defaultProfanities, defaultFalseNegatives, defaultFalsePositives),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, s := range sentences {
+				if tt.goAway.IsProfane(s) {
+					t.Error("Expected false, got true from:", s)
+				}
+			}
+		})
 	}
 }
 
@@ -133,21 +264,57 @@ func TestFalseNegatives(t *testing.T) {
 	sentences := []string{
 		"dumb ass", // ass -> bASS (FP) -> dumBASS (FFP)
 	}
-	goAway := NewProfanityDetector()
-	for _, s := range sentences {
-		if !goAway.IsProfane(s) {
-			t.Error("Expected false, got true from:", s)
-		}
+
+	tests := []struct {
+		name   string
+		goAway *ProfanityDetector
+	}{
+		{
+			name:   "With Default Dictionary",
+			goAway: NewProfanityDetector(),
+		},
+		{
+			name:   "With Custom Dictionary",
+			goAway: NewProfanityDetector().WithCustomDictionary(defaultProfanities, defaultFalseNegatives, defaultFalsePositives),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, s := range sentences {
+				if !tt.goAway.IsProfane(s) {
+					t.Error("Expected false, got true from:", s)
+				}
+			}
+		})
 	}
 }
 
 func TestSentencesWithFalsePositivesAndProfanities(t *testing.T) {
 	sentences := []string{"You are a shitty associate", "Go away, asshole!"}
-	goAway := NewProfanityDetector()
-	for _, s := range sentences {
-		if !goAway.IsProfane(s) {
-			t.Error("Expected true, got false from sentence", s)
-		}
+
+	tests := []struct {
+		name   string
+		goAway *ProfanityDetector
+	}{
+		{
+			name:   "With Default Dictionary",
+			goAway: NewProfanityDetector(),
+		},
+		{
+			name:   "With Custom Dictionary",
+			goAway: NewProfanityDetector().WithCustomDictionary(defaultProfanities, defaultFalseNegatives, defaultFalsePositives),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, s := range sentences {
+				if !tt.goAway.IsProfane(s) {
+					t.Error("Expected true, got false from sentence", s)
+				}
+			}
+		})
 	}
 }
 
@@ -180,6 +347,7 @@ func TestSentencesFromTheAdventuresOfSherlockHolmes(t *testing.T) {
 		"Within there was a small corridor, which ended in a very massive iron gate.",
 		"We were seated at breakfast one morning, my wife and I, when the maid brought in a telegram. It was from Sherlock Holmes and ran in this way",
 	}
+
 	for _, s := range sentences {
 		if IsProfane(s) {
 			t.Error("Expected false, got false from sentence", s)

--- a/goaway_test.go
+++ b/goaway_test.go
@@ -8,7 +8,7 @@ func TestNoDuplicatesBetweenProfanitiesAndFalseNegatives(t *testing.T) {
 	for _, profanity := range defaultProfanities {
 		for _, falseNegative := range defaultFalseNegatives {
 			if profanity == falseNegative {
-				t.Errorf("'%s' is already in 'defaultFalseNegatives', there's no need to have it in 'defaultProfanities' too", profanity)
+				t.Errorf("'%s' is already in 'falseNegatives', there's no need to have it in 'profanities' too", profanity)
 			}
 		}
 	}

--- a/profanities.go
+++ b/profanities.go
@@ -40,7 +40,7 @@ var defaultProfanities = []string{
 	"fudgepacker",
 	"flange",
 	"gtfo",
-	"hoe", // while that's also a tool, I doubt somebody would be checking for defaultProfanities if that tool was relevant
+	"hoe", // while that's also a tool, I doubt somebody would be checking for profanities if that tool was relevant
 	"horny",
 	"incest",
 	"jerk",

--- a/profanities.go
+++ b/profanities.go
@@ -1,9 +1,9 @@
 package goaway
 
-// profanities is a list of profanities that are checked after the falsePositives are removed
+// defaultProfanities is a list of defaultProfanities that are checked after the defaultFalsePositives are removed
 //
-// Note that some words that would normally be in this list may be in falseNegatives
-var profanities = []string{
+// Note that some words that would normally be in this list may be in defaultFalseNegatives
+var defaultProfanities = []string{
 	"anal",
 	"anus",
 	"arse",
@@ -40,7 +40,7 @@ var profanities = []string{
 	"fudgepacker",
 	"flange",
 	"gtfo",
-	"hoe", // while that's also a tool, I doubt somebody would be checking for profanities if that tool was relevant
+	"hoe", // while that's also a tool, I doubt somebody would be checking for defaultProfanities if that tool was relevant
 	"horny",
 	"incest",
 	"jerk",

--- a/profanities.go
+++ b/profanities.go
@@ -1,9 +1,9 @@
 package goaway
 
-// defaultProfanities is a list of defaultProfanities that are checked after the defaultFalsePositives are removed
+// DefaultProfanities is a list of DefaultProfanities that are checked after the DefaultFalsePositives are removed
 //
-// Note that some words that would normally be in this list may be in defaultFalseNegatives
-var defaultProfanities = []string{
+// Note that some words that would normally be in this list may be in DefaultFalseNegatives
+var DefaultProfanities = []string{
 	"anal",
 	"anus",
 	"arse",

--- a/profanities.go
+++ b/profanities.go
@@ -1,6 +1,6 @@
 package goaway
 
-// DefaultProfanities is a list of DefaultProfanities that are checked after the DefaultFalsePositives are removed
+// DefaultProfanities is a list of profanities that are checked after the DefaultFalsePositives are removed
 //
 // Note that some words that would normally be in this list may be in DefaultFalseNegatives
 var DefaultProfanities = []string{


### PR DESCRIPTION
This PR is related with the issue #16.

So I created a new functional function to enable a way where you can load different `profanities`, `falseNegatives` and `falsePositives` in this way this library will be more versatile, also I modified the test related and the README 